### PR TITLE
Update "hackers" to the more correct terms.

### DIFF
--- a/pages/policy-principles.md
+++ b/pages/policy-principles.md
@@ -173,9 +173,11 @@ If the agency is aware:
 
 (b) that other government agencies are using the software,
 
-the agency should inform the Government Chief Information Officer (and where relevant the Government Chief Privacy Officer and Office of the Privacy Commissioner) as soon as possible, take all reasonable steps to inform the other agencies of the risk and give them time to mitigate the risk before making any public announcement that could result in hackers or others exploiting the bug or other issue.
+the agency should inform the Government Chief Information Officer (and where relevant the Government Chief Privacy Officer and Office of the Privacy Commissioner) as soon as possible, take all reasonable steps to inform the other agencies of the risk and give them time to mitigate the risk before making any public announcement that could result in malicious adversaries or crackers[^10] exploiting the bug or other issue.
 
-### Code forking[^10]
+[^10]: See the Internet Security Glossary, Version 2 on Crackers [https://tools.ietf.org/html/rfc4949#page-84](https://tools.ietf.org/html/rfc4949#page-84)
+
+### Code forking[^11]
 
 ##### 29
 
@@ -185,7 +187,7 @@ Code forking occurs when agencies make changes to the code of open source softwa
 
 Where an agency has taken and modified open source software, it should contribute the modified software back to the open source community unless there is a compelling reason not to do so.
 
-[^10]: This principle is based in part on a discussion of code forking in the Australian Government's *A Guide to Open Source Software for Australian Government Agencies*, above n 1, but has been modified for the purposes of NZGOAL-SE. Most of the Australian Guide has been released under a Creative Commons Attribution 3.0 Australia licence: [http://creativecommons.org/licenses/by/3.0/au/](http://creativecommons.org/licenses/by/3.0/au/).
+[^11]: This principle is based in part on a discussion of code forking in the Australian Government's *A Guide to Open Source Software for Australian Government Agencies*, above n 1, but has been modified for the purposes of NZGOAL-SE. Most of the Australian Guide has been released under a Creative Commons Attribution 3.0 Australia licence: [http://creativecommons.org/licenses/by/3.0/au/](http://creativecommons.org/licenses/by/3.0/au/).
 
 ### Obtaining rights when procuring or commissioning the development of software
 

--- a/pages/review-and-release-process.md
+++ b/pages/review-and-release-process.md
@@ -4,7 +4,7 @@ title: NZGOAL-SE Review and release process
 permalink: /review-and-release-process/
 description: "NZGOAL-SE Review and release process"
 ---
-{::options footnote_nr="11" /}
+{::options footnote_nr="12" /}
 
 ## NZGOAL-SE Review and Release Process
 
@@ -66,11 +66,11 @@ In the vast majority of cases, software that an agency wishes to license will co
 
 When an agency is in the situation of not owning all copyright in the software it would like to release and license for re-use and needs permission from the copyright owner(s), it is important to appreciate that the software may:
 
-(a) comprise all new code (i.e., be a completely new copyright work);[^11] or
+(a) comprise all new code (i.e., be a completely new copyright work);[^12] or
 
 (b) build on pre-existing code (i.e., be an adaptation / derivative of pre-existing code).
 
-[^11]: For example, the software could be a deliverable under a services contract the agency has with a vendor, but the contract may confer copyright ownership on the service provider and only license the software to the agency.
+[^12]: For example, the software could be a deliverable under a services contract the agency has with a vendor, but the contract may confer copyright ownership on the service provider and only license the software to the agency.
 
 ##### 45
 
@@ -90,11 +90,11 @@ The analysis for these two scenarios is different:
 
 >(ii) to the extent that the agency does not own the copyright in the adaptation / derivative work, have permission from the other copyright owner(s) for their parts of the overall new work to be licensed under the open source software licence the agency wishes to use.
 
-To understand this, one needs to appreciate that an adaptation / derivative work consists of property (copyright) owned by the original licensor(s) (let’s call them A) plus new and separate property (copyright) over the new original parts of the adaptation / derivative work that are created by B. The derivative work is a distinct copyright work in its own right but B doesn’t obtain property rights that are greater than B’s own contribution. As a United States court has put it, "[t]he aspects of a derivative work added by the derivative author are that author’s property, but the element drawn from the pre-existing work remains on grant from the owner of the pre-existing work".[^12]
+To understand this, one needs to appreciate that an adaptation / derivative work consists of property (copyright) owned by the original licensor(s) (let’s call them A) plus new and separate property (copyright) over the new original parts of the adaptation / derivative work that are created by B. The derivative work is a distinct copyright work in its own right but B doesn’t obtain property rights that are greater than B’s own contribution. As a United States court has put it, "[t]he aspects of a derivative work added by the derivative author are that author’s property, but the element drawn from the pre-existing work remains on grant from the owner of the pre-existing work".[^13]
 
 Depending on the number of pre-existing owners, the licences (if any) under which they may have released their code and the licence the agency wishes to apply to the adaptation / derivative work, this can get complex very quickly. In cases of any complexity, agencies may need to seek expert legal advice.
 
-[^12]: Stewart v Abend 495 U.S. 207, 223 (1990).
+[^13]: Stewart v Abend 495 U.S. 207, 223 (1990).
 
 #### Common scenarios where agency will not be able to license software under the MIT licence
 
@@ -160,9 +160,9 @@ If a sharealike open source software licence is to be applied because the agency
 
 GPL-compatibility is important given the large volume of software that has been released under the GPL. The Free Software Foundation maintains a list of licences it considers to be GPL-compatible. Note that only some of these are sharealike (copyleft) licences.
 
-### Stage 4: Application of chosen licence[^13]
+### Stage 4: Application of chosen licence[^14]
 
-[^13]: For a useful general discussion of this topic, see the Software Freedom Law Center’s "Managing copyright information within a free software project" at [http://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html](http://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html])
+[^14]: For a useful general discussion of this topic, see the Software Freedom Law Center’s "Managing copyright information within a free software project" at [http://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html](http://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html])
 
 #### Introduction
 
@@ -232,9 +232,9 @@ SpatialZone Project, Crown copyright (c) 2015, Land Information New Zealand on b
 
 ##### 59
 
-Full instructions on how to apply can be found on the Free Software Foundation’s [website](http://www.gnu.org/licenses/gpl-howto.html).[^14]
+Full instructions on how to apply can be found on the Free Software Foundation’s [website](http://www.gnu.org/licenses/gpl-howto.html).[^15]
 
-[^14]: See "How to use GNU licenses for your own software" at [http://www.gnu.org/licenses/gpl-howto.html](http://www.gnu.org/licenses/gpl-howto.html)
+[^15]: See "How to use GNU licenses for your own software" at [http://www.gnu.org/licenses/gpl-howto.html](http://www.gnu.org/licenses/gpl-howto.html)
 
 #### Other licences
 


### PR DESCRIPTION
See the conversation at https://www.loomio.org/d/SEshIfzW/use-of-the-term-hacker- it was agreed that the term "Hacker" now carries a positive connotation, for example "Hack-a-thons" such as GovHack. The more correct term was to use adversary or cracker and specifically the behaviour they were performing in relation to para. 28 in NZGOAL-SE was malicious exploitation of bugs.

We've made reference to the Internet Security Glossary for a full definition of "Cracker" as this term is often confused with the former term, Hacker.
