### PR TITLE
Rework of Adaptions section

### DIFF
--- a/pages/policy-principles.md
+++ b/pages/policy-principles.md
@@ -20,7 +20,6 @@ Government agencies are strongly encouraged to apply the following Policy Princi
 | Ensuring copyright ownership or right to sub-license                             | Make sure your agency has the required copyright-related rights to license the software.                                                                                                                                                                                |
 | Exceptions                                                                       | The default MIT licensing does not apply where an exception applies.                                                                                                                                                                                                    |
 | Adaptations                                                                      | Be careful when considering whether you’re adapting pre-existing software.                                                                                                                                                                                              |
-| Alternative OSS licensing                                                        | Where the default MIT licensing does not apply due to an upstream OSS licensing obligation (e.g., under the GPL), license with upstream licence. Where the agency has a compelling reason for sharealike licensing, license with the GPL (or a GPL-compatible licence). |
 | Security code review                                                             | Consider whether a security code review is required to identify sensitive elements that may need to be removed.                                                                                                                                                         |
 | No additional controls or discrimination                                         | Do not seek to impose requirements that are inconsistent with the freedoms in the chosen OSS licence.                                                                                                                                                                   |
 | No charging                                                                      | Do not charge people for access to OSS-licensed software.                                                                                                                                                                                                               |
@@ -33,12 +32,11 @@ Government agencies are strongly encouraged to apply the following Policy Princi
 
 Each Policy Principle is set out below.
 
-
 ### Open access and public release of agency software using free and open source licences.
 
 ##### 14
 
-If government agencies have the required copyright-related rights to do so, they are encouraged to consider making their software source code and documentation, that is or may be of interest or use to people, available for re-use and adaption:
+If government agencies have the required copyright-related rights to do so, they are encouraged to consider making their software source code and accompanying documentation, that is or may be of interest or use to people, available for re-use and adaption:
 
 (a) under a free and open source software licence from the NZGOAL-SE review and release process and decision tree, unless an exception in paragraph 18 applies; and
 
@@ -62,7 +60,7 @@ For the purposes of NZGOAL-SE, the recommended set of free and open source softw
 
 [^7]: The MIT licence is considered preferable to the BSD 3-Clause licence (another commonly-used permissive open source software licence) because the MIT licence includes a clearer grant of rights and expressly includes the right to sub-license (the BSD licence does not). Whilst many interpret a right to sub-license as being implicit in the BSD licence, the absence of an express reference to it in the BSD licence could produce uncertainty for users, most notably users who wish to incorporate government-produced code in a work licensed under the GPL. The Free Software Foundation considers the BSD licence to be  ompatible with the GPL but that must depend on a particular interpretation of the BSD licence wording (see generally A Sinclair “License Profile: BSD” IFOSS Law Review, 2(1) pp. 1-6). The MIT licence doesn’t contain the BSD’s ‘no endorsement’ clause but, in most cases, the law would prevent claims of endorsement without permission anyway. Another common permissive licence, the Apache License 2.0, was not chosen because it is more complex. The Free Software Foundation considers it preferable to the BSD and MIT licences as it deals with patent licensing and prevents ‘patent treachery’. However, in New Zealand the Patents Act 2013 excludes computer programs "as such" from patentable subject matter (and, in any event, historically government agencies have not generally been in the business of applying for software patents). NZGOAL-SE could have recommended its own bespoke permissive licence instead of the MIT licence but that would have contributed to further licence proliferation and exposed developers to a licence they’re not familiar with.
 
-[^8]: MIT as used in NZGOAL-SE refers to the 'Expat licence'. See [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
+[^8]: MIT as used in NZGOAL-SE refers to the 'Expat' licence. See [https://opensource.org/licenses/MIT](https://opensource.org/licenses/MIT)
 
 [^9]: GPL as used in NZGOAL-SE refers to the GNU General Public Licence version 3 or later. See [http://www.gnu.org/licenses/gpl-3.0.en.html](http://www.gnu.org/licenses/gpl-3.0.en.html)
 
@@ -80,7 +78,7 @@ Agencies should only license software for re-use by others under any free and op
 
 (b) to the extent they do not own the copyright, they have or can obtain permission from the copyright owner(s) to do so
 
-(the **Rights Clearance Principle**). It can be important, in this context, to check that if developers have reused tracts of code from elsewhere, that the licence of these are also considered in the evaluation of copyright-related rights.
+(the **Rights Clearance Principle**). It can be important, in this context, to check that if developers have reused tracts of code from elsewhere, that the licence of these snippets are also considered in the evaluation of copyright-related rights.
 
 ### Exceptions
 
@@ -98,36 +96,33 @@ The Open Access and Licensing Principle does not apply where:
 
 ##### 19
 
-Difficult legal questions can arise as to whether a given piece of developed software, that in some way leverages or interacts with other software, is an adaptation or derivative of that software. If:
+An agency may incorporate or adapt pre-existing software source code that is licensed under one or more free and open source software licences. Alternatively, an agency may produce new software source code that interacts with a pre-existing free and open source software application. Take a plug-in or extension to an existing application as an example. Depending on the context, a plug-in or extension may be an adaptation of pre-existing source code (e.g., where it has forked an old plug-in or extension) or it may be new source code designed to interact with a pre-existing application but without taking any pre-existing source code.
 
-(a) an agency’s developed software does leverage or interact with other software; and
+If an agency proposes to release its source code in these kinds of situations, the agency should:
 
-(b) that other software is third party proprietary software or software owned by a third party that has been released under a sharealike open source software licence like the GPL,
+(a) respect the terms and conditions of the existing licences (such as attribution requirements); and
 
-the agency should be cautious about concluding that it's developed software is _not_ an adaptation or derivative of the other software. The need for caution arises because if the agency concludes mistakenly that the developed software is not an adaptation, release of the developed software under an incorrect licence could result in the agency breaching third party rights and expose it to the risk of complaint or legal action. End users would also be at risk of breaching third party rights and be exposed to the risk of complaint or legal action. If an agency is in any doubt on this issue, it should seek specialist advice (which could be both technical and legal) before releasing the software for re-use.
+(b) where possible, use the same free and open source licence or licences applying to the pre-existing software source code, even in cases where - strictly speaking - it is not required to do so
 
-### Alternative OSS licensing
+(the **Respect Existing Licences Principle**).
+
+It is important to note that using more permissively-licensed source code (e.g., MIT-licensed source code) and sharealike/copyleft-licensed source code (e.g., GPL-licensed source code) together in a broader project may require you to release your new source code under the same sharealike/copyleft licence or a compatible licence (in most cases the licence will be version 2 or 3 of the GPL)[^10] rather than under the more permissive licence. Whether this is the case depends on the circumstances. Legal advice should be sought if required.   
+
+[^10]: Whilst versions 2 and 3 of the GPL differ in certain respects, in essence the GPL allows people to copy and distribute the software, to charge a fee for transferring it or providing warranty protection, and to modify the software and distribute resulting derivative works. And, if a person distributes a derivative work, that person needs to license it under the GPL, otherwise that person's licence to use the software will terminate. The full text of versions 2 and 3 of the GPL (both versions are in common use) can be found on the website of the [Free Software Foundation](http://www.gnu.org/licenses/gpl-3.0.en.html) at [http://www.gnu.org/licenses/gpl-3.0.en.html](http://www.gnu.org/licenses/gpl-3.0.en.html).
 
 ##### 20
 
-Where the Permissive Licensing Principle does not apply because:
+Difficult legal questions can arise as to whether a given piece of developed software, that in some way leverages or interacts with other software, is in fact an adaptation or derivative of that software. If:
 
-(a) the software is an adaptation or derivative of open source software that is licensed under a sharealike OSS licence, the agency should release the software and license it under the same sharealike OSS licence (in most cases the licence will be version 2 or 3 of the GPL); or
+(a) an agency’s developed software does leverage or interact with other software; and
 
-(b) the agency has compelling reason for licensing the software with a sharealike licence, the agency should release the software under the GPL.
+(b) that other software, or part of it, is third party proprietary software or software owned by a third party that has been released under a sharealike open source software licence like the GPL,
 
-##### 21
-
-Whilst versions 2 and 3 of the GPL differ in certain respects, in essence the GPL allows people to copy and distribute the software, to charge a fee for transferring it or providing warranty protection, and to modify the software and distribute resulting derivative works. But, if a person distributes his or her derivative work, that person needs to license it under the GPL, otherwise that person's licence to use the software will terminate. The full text of versions 2 and 3 of the GPL (both versions are in common use) can be found on the website of the [Free Software Foundation](http://www.gnu.org/licenses/gpl-3.0.en.html).[^11]
-
-[^11]: See [http://www.gnu.org/licenses/gpl-3.0.en.html](http://www.gnu.org/licenses/gpl-3.0.en.html)
-
-
-
+the agency should be cautious about concluding that its developed software is _not_ an adaptation or derivative of the other software. The need for caution arises because if the agency concludes mistakenly that the developed software is not an adaptation, release of the developed software under an incorrect licence could result in the agency breaching third party rights and expose it to the risk of complaint or legal action. End users would also be at risk of breaching third party rights and be exposed to the risk of complaint or legal action. If an agency is in any doubt on this issue, it should seek specialist advice (which could be both technical and legal) before releasing the software for re-use.
 
 ### Security code review
 
-##### 22
+##### 21
 
 Before releasing software for re-use, agencies should:
 
@@ -137,19 +132,19 @@ Before releasing software for re-use, agencies should:
 
 ### No additional controls or discrimination
 
-##### 23
+##### 22
 
 When releasing developed software under an open source software licence, agencies must not seek to impose controls or requirements, whether contractual or otherwise, that are inconsistent with the freedoms or permissions granted by the selected OSS licence. For example, agencies are _not_ able to license software under an open source software licence and then seek to discriminate between individual, not-for-profit and commercial uses of the software.
 
 ### No charging
 
-##### 24
+##### 23
 
 Government agencies that release software under open source software licences should not seek to charge people for access to the software.
 
 ### Updating open source licensed software
 
-##### 25
+##### 24
 
 If an agency:
 
@@ -157,13 +152,13 @@ If an agency:
 
 (b) subsequently identifies a bug or other issue with the software that could have a material adverse effect on users of the software,
 
-the agency should (subject to paragraph 26):
+the agency should (subject to paragraph 25):
 
 (c) consider whether to inform users of the software of the bug or other issue (e.g., by adding a notice to the repository, site or service that contains the software files); and
 
 (d) if the agency has rectified the bug or other issue for its own purposes, release the updated file(s) to the relevant repository, site or service.
 
-##### 26
+##### 25
 
 If the agency is aware:
 
@@ -171,25 +166,25 @@ If the agency is aware:
 
 (b) that other government agencies are using the software,
 
-the agency should inform the Government Chief Information Officer (and where relevant the Government Chief Privacy Officer and Office of the Privacy Commissioner) as soon as possible, take all reasonable steps to inform the other agencies of the risk and give them time to mitigate the risk before making any public announcement that could result in malicious adversaries or crackers[^12] exploiting the bug or other issue.
+the agency should inform the Government Chief Information Officer (and where relevant the Government Chief Privacy Officer and Office of the Privacy Commissioner) as soon as possible, take all reasonable steps to inform the other agencies of the risk and give them time to mitigate the risk before making any public announcement that could result in malicious adversaries or crackers[^11] exploiting the bug or other issue.
 
-[^12]: See the Internet Security Glossary, Version 2 on Crackers [https://tools.ietf.org/html/rfc4949#page-84](https://tools.ietf.org/html/rfc4949#page-84)
+[^11]: See the Internet Security Glossary, Version 2 on Crackers [https://tools.ietf.org/html/rfc4949#page-84](https://tools.ietf.org/html/rfc4949#page-84)
 
-### Code forking[^13]
+### Code forking[^12]
 
-##### 27
+##### 26
 
 Code forking occurs when agencies make changes to the code of open source software without publishing the code back to the software’s development community. The fork is the split between the agency’s version of the software and the version published by the community. Any further changes made by either the agency or the community will increase the fork. This can make it difficult for the agency to upgrade to a new published version, as the agency would have to reapply all its changes. This risk may be mitigated by contributing modified source code back to the open source software community.
 
-##### 28
+##### 27
 
 Where an agency has taken and modified open source software, it should contribute the modified software back to the open source community unless there is a compelling reason not to do so.
 
-[^13]: This principle is based in part on a discussion of code forking in the Australian Government's *A Guide to Open Source Software for Australian Government Agencies*, above n 1, but has been modified for the purposes of NZGOAL-SE. Most of the Australian Guide has been released under a Creative Commons Attribution 3.0 Australia licence: [http://creativecommons.org/licenses/by/3.0/au/](http://creativecommons.org/licenses/by/3.0/au/).
+[^12]: This principle is based in part on a discussion of code forking in the Australian Government's *A Guide to Open Source Software for Australian Government Agencies*, above n 1, but has been modified for the purposes of NZGOAL-SE. Most of the Australian Guide has been released under a Creative Commons Attribution 3.0 Australia licence: [http://creativecommons.org/licenses/by/3.0/au/](http://creativecommons.org/licenses/by/3.0/au/).
 
 ### Obtaining rights when procuring or commissioning the development of software
 
-##### 29
+##### 28
 
 When procuring or commissioning the development of software, government agencies should consider whether the software should, in accordance with these Policy Principles, be released to the public for re-use under an open source software licence. If the software should be released to the public for re-use under an open source software licence, government agencies should consider the steps that may be required as part of their procurement and contracting processes to ensure that either:
 
@@ -215,17 +210,17 @@ Taking these steps may require:
 
 (i) ensuring that the contract does not include confidentiality provisions that would inadvertently prevent release of the software under an open source software licence.
 
+##### 29
+
+Paragraph 28 is subject to any statutory, policy or commercial imperatives to the contrary.
+
 ##### 30
-
-Paragraph 29 is subject to any statutory, policy or commercial imperatives to the contrary.
-
-##### 31
 
 The Guidelines for the Treatment of Intellectual Property Rights in ICT Contracts are _not_ a policy imperative to the contrary. Rather, they – like NZGOAL-SE – are government policy for agencies to take into account at the time of procuring software. As explained at paragraph 11 above, those Guidelines and NZGOAL-SE are complimentary.
 
 ### Act fairly towards developers when drafting IP warranties and indemnities
 
-##### 32
+##### 31
 
 If:
 
@@ -235,18 +230,18 @@ If:
 
 the agency should act fairly towards the service provider in relation to the drafting of intellectual property warranties and indemnities.
 
-##### 33
+##### 32
 
 In particular, it is generally considered unreasonable to expect a service provider to give an unqualified IP warranty and an unqualified IP indemnity in relation to third party open source software that the agency agrees can be used by the service provider in developing software for the agency. This is especially so when the agency will be releasing the developed software under an open source software licence or requires the service provider to do so on its behalf.
 
 ### Liability
 
-##### 34
+##### 33
 
 The MIT licence and the GPL both contain broad disclaimers of warranties and exclusions of liability that are widely known and acknowledged and ought to protect releasing agencies from liability in connection with the software they have released. In essence, people use free and open source software at their own risk. Agencies should ensure that all disclaimers and exclusions contained in the MIT licence or the GPL (as applicable) are replicated when they release software under these licences.
 
 ### Review and Release Process
 
-##### 35
+##### 34
 
 Government agencies should follow the NZGOAL-SE Review and Release Process before publicly releasing and licensing their software for re-use under a free and open source software licence. The Review and Release Process is set out below.

--- a/pages/review-and-release-process.md
+++ b/pages/review-and-release-process.md
@@ -4,13 +4,13 @@ title: NZGOAL-SE Review and release process
 permalink: /review-and-release-process/
 description: "NZGOAL-SE Review and release process"
 ---
-{::options footnote_nr="14" /}
+{::options footnote_nr="13" /}
 
 ## NZGOAL-SE Review and Release Process
 
-### Introduction 
+### Introduction
 
-##### 36
+##### 35
 
 It is recommended that government agencies follow the review and release process set out below before releasing software for re-use under an open source software licence, with assistance where required from their technical and legal teams. The process consists of five main stages:
 
@@ -20,15 +20,15 @@ It is recommended that government agencies follow the review and release process
 
 (c) alternative OSS licensing;
 
-(d) application of the chosen licence; and 
+(d) application of the chosen licence; and
 
 (e) release of the software.
 
+##### 36
+
+Each stage contains one or more issues that may need to be worked through. The stages and the issues within them reflect a mixture of the NZGOAL-SE Policy Principles, legal requirements and practical considerations.
+
 ##### 37
-
-Each stage contains one or more issues that may need to be worked through. The stages and the issues within them reflect a mixture of the NZGOAL-SE Policy Principles, legal requirements and practical considerations. 
-
-##### 38 
 
 It can be important to work through these steps to ensure that the agency:
 
@@ -38,51 +38,51 @@ It can be important to work through these steps to ensure that the agency:
 
 (c) does not expose either itself or those who may re-use the released software to liability or related risk.
 
-##### 39
+##### 38
 
-A decision tree diagram for the review and release process is set out at paragraph 61 below. 
+A decision tree diagram for the review and release process is set out at paragraph 61 below.
 
-### Stage 1: Copyright-related rights evaluation 
+### Stage 1: Copyright-related rights evaluation
 
 #### What the stage involves
 
-##### 40
+##### 39
 
 The first stage involves:
 
-(a) clearly identifying the boundaries of the software that the agency proposes to release (e.g., the software may comprise a range of files, all of which would need to be released together); 
+(a) clearly identifying the boundaries of the software that the agency proposes to release (e.g., the software may comprise a range of files, all of which would need to be released together);
 
 (b) determining whether that software constitutes or contains one or more copyright works; and, if so
 
-(c) evaluating whether the agency has sufficient rights to license the software under the MIT licence in accordance with the Permissive Licensing Principle. 
+(c) evaluating whether the agency has sufficient rights to license the software under the MIT licence in accordance with the Permissive Licensing Principle.
 
-##### 41
+##### 40
 
 In the vast majority of cases, software that an agency wishes to license will constitute or contain one or more copyright works. In the unlikely event that a given piece of software does not constitute or contain one or more copyright works, an agency could, if no exception in Stage 2 applies, release it into the public domain using an NZGOAL-style “no known rights” statement. See NZGOAL for that statement. It is not discussed further in NZGOAL-SE.
 
 #### Issues where agency does not own all copyright
 
-##### 42
+##### 41
 
 When an agency is in the situation of not owning all copyright in the software it would like to release and license for re-use and needs permission from the copyright owner(s), it is important to appreciate that the software may:
 
-(a) comprise all new code (i.e., be a completely new copyright work);[^14] or
+(a) comprise all new code (i.e., be a completely new copyright work);[^13] or
 
 (b) build on pre-existing code (i.e., be an adaptation / derivative of pre-existing code).
 
-[^14]: For example, the software could be a deliverable under a services contract the agency has with a vendor, but the contract may confer copyright ownership on the service provider and only license the software to the agency.
+[^13]: For example, the software could be a deliverable under a services contract the agency has with a vendor, but the contract may confer copyright ownership on the service provider and only license the software to the agency.
 
-##### 43
+##### 42
 
 The analysis for these two scenarios is different:
 
 (a) **All new code**: In the case of all new code that the agency doesn’t own but wishes to license, the agency would need to either:
 
->(i) already be entitled, under an open source software licence that the owner has recently applied to the software, to sub-license the software; or 
+>(i) already be entitled, under an open source software licence that the owner has recently applied to the software, to sub-license the software; or
 
->(ii) obtain irrevocable written permission from the copyright owner to sub-license the software on the relevant open source software licence terms. 
+>(ii) obtain irrevocable written permission from the copyright owner to sub-license the software on the relevant open source software licence terms.
 
->**Notes on sub-licensing**: As to the first option, it is important to note three points. First, if the software has already been licensed under an open source software licence, there may be no need for the agency to sub-license it because anyone who gets the software has the rights granted by the licence that the owner has applied. Second, some open source software licences prohibit sub-licensing. For example, you cannot sub-license GPL-licensed software. Third, if there is a right to sub-license, that right would need to be broad enough to allow sub-licensing under the particular open source software licence that the agency wishes to apply to the software. 
+>**Notes on sub-licensing**: As to the first option, it is important to note three points. First, if the software has already been licensed under an open source software licence, there may be no need for the agency to sub-license it because anyone who gets the software has the rights granted by the licence that the owner has applied. Second, some open source software licences prohibit sub-licensing. For example, you cannot sub-license GPL-licensed software. Third, if there is a right to sub-license, that right would need to be broad enough to allow sub-licensing under the particular open source software licence that the agency wishes to apply to the software.
 
 (b) **Adaptation / derivative of pre-existing code**: In the case of an adaptation / derivative of pre-existing code, the agency would need to:
 
@@ -90,17 +90,17 @@ The analysis for these two scenarios is different:
 
 >(ii) to the extent that the agency does not own the copyright in the adaptation / derivative work, have permission from the other copyright owner(s) for their parts of the overall new work to be licensed under the open source software licence the agency wishes to use.
 
-To understand this, one needs to appreciate that an adaptation / derivative work consists of property (copyright) owned by the original licensor(s) (let’s call them A) plus new and separate property (copyright) over the new original parts of the adaptation / derivative work that are created by B. The derivative work is a distinct copyright work in its own right but B doesn’t obtain property rights that are greater than B’s own contribution. As a United States court has put it, "[t]he aspects of a derivative work added by the derivative author are that author’s property, but the element drawn from the pre-existing work remains on grant from the owner of the pre-existing work".[^15]
+To understand this, one needs to appreciate that an adaptation / derivative work consists of property (copyright) owned by the original licensor(s) (let’s call them A) plus new and separate property (copyright) over the new original parts of the adaptation / derivative work that are created by B. The derivative work is a distinct copyright work in its own right but B doesn’t obtain property rights that are greater than B’s own contribution. As a United States court has put it, "[t]he aspects of a derivative work added by the derivative author are that author’s property, but the element drawn from the pre-existing work remains on grant from the owner of the pre-existing work".[^14]
 
 Depending on the number of pre-existing owners, the licences (if any) under which they may have released their code and the licence the agency wishes to apply to the adaptation / derivative work, this can get complex very quickly. In cases of any complexity, agencies may need to seek expert legal advice.
 
-[^15]: Stewart v Abend 495 U.S. 207, 223 (1990).
+[^14]: Stewart v Abend 495 U.S. 207, 223 (1990).
 
 #### Common scenarios where agency will not be able to license software under the MIT licence
 
-##### 44
+##### 43
 
-There are certain scenarios in which, from a copyright perspective, an agency will not be able to license software under the MIT licence. Three common scenarios are as follows: 
+There are certain scenarios in which, from a copyright perspective, an agency will not be able to license software under the MIT licence. Three common scenarios are as follows:
 
 (a) **third party owner**: copyright in the software is owned by a third party and the agency is not permitted to license the software for re-use under the MIT licence;
 
@@ -110,19 +110,19 @@ There are certain scenarios in which, from a copyright perspective, an agency wi
 
 ### Stage 2: Evaluation of exceptions
 
-##### 45
+##### 44
 
 If an agency has completed Stage 1 and concluded that it does have sufficient rights to license the software under the MIT licence, then the NZGOAL-SE Policy Principles recommend that the software be licensed with the MIT licence unless an exception set out in paragraph 20 applies.
 
+##### 45
+
+For each proposed release, the exceptions need to be considered in the light of all the surrounding circumstances relevant to the specific software and its release.
+
 ##### 46
-
-For each proposed release, the exceptions need to be considered in the light of all the surrounding circumstances relevant to the specific software and its release. 
-
-##### 47
 
 In many instances, the exercise will be quick as none of the restrictions will apply. In that event, the agency can move to Stage 4 (Application of chosen licence) below. This is because the Permissive Licensing Principle will not have been displaced.
 
-##### 48
+##### 47
 
 If one or more of the exceptions applies, the Permissive Licensing Principle will be displaced and not apply. One of two consequences will follow:
 
@@ -132,11 +132,11 @@ If one or more of the exceptions applies, the Permissive Licensing Principle wil
 
 ### Stage 3: Alternative OSS licensing
 
-##### 49
+##### 48
 
 Stage 3 only applies where the exception in paragraph 18(d) applies (sharealike required) and no other exceptions apply. If no exception applies, the agency should move to Stage 4 (Application of chosen licence).
 
-##### 50
+##### 49
 
 As noted in paragraph 18(d), a sharealike open source software licence may need to be applied either because:
 
@@ -144,40 +144,40 @@ As noted in paragraph 18(d), a sharealike open source software licence may need 
 
 (b) because the agency has a genuine need for developments to the software to be shared with the developer community.
 
-##### 51
+##### 50
 
 If the agency is required to license the software under a particular sharealike licence, it must license the software under that licence (failure to do so would likely result in the agency breaching third party rights). Where this is the case, the agency should proceed to Stage 4 (Application of chosen licence).
 
-##### 52
+##### 51
 
 If a sharealike open source software licence is to be applied because the agency has a genuine need for developments to the software to be shared with the developer community, the agency is encouraged to use either:
 
 (a) the GPL (version 2 or 3, with version 3 being preferable); or
 
-(b) a sharealike OSS licence that is GPL-compatible. 
+(b) a sharealike OSS licence that is GPL-compatible.
 
-##### 53
+##### 52
 
 GPL-compatibility is important given the large volume of software that has been released under the GPL. The Free Software Foundation maintains a list of licences it considers to be GPL-compatible. Note that only some of these are sharealike (copyleft) licences.
 
-### Stage 4: Application of chosen licence[^16]
+### Stage 4: Application of chosen licence[^15]
 
-[^16]: For a useful general discussion of this topic, see the Software Freedom Law Center’s "Managing copyright information within a free software project" at [http://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html](http://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html])
+[^15]: For a useful general discussion of this topic, see the Software Freedom Law Center’s "Managing copyright information within a free software project" at [http://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html](http://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html])
 
 #### Introduction
 
-##### 54
+##### 53
 
 Stage 4 explains how agencies apply their chosen open source software licence to the software they’re releasing.
 
 #### Applying the MIT licence
 
-##### 55
+##### 54
 
 This is the standard MIT licence:
 
 ```
-MIT Licence	
+MIT Licence
 
 Copyright (c) <year> <copyright holders>
 
@@ -188,16 +188,16 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-##### 56
+##### 55
 
 Agencies can apply the MIT licence in one of two ways:
 
 (a) They can reproduce the full text of the licence above at the top of each software file they are licensing. When doing so, they need to add the year the software was completed and who the copyright holders are. If the licensing agency is a department of the Crown, it should also replace “Copyright” with “Crown copyright”. For example, if the licensing agency were a department, its licensing statement would look something like this:
 
 ```
-MIT Licence	
+MIT Licence
 
-Crown copyright (c) 2015, Land Information New Zealand on behalf of the New Zealand Government. 
+Crown copyright (c) 2015, Land Information New Zealand on behalf of the New Zealand Government.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -206,7 +206,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-If the licensing agency is not part of the Crown (e.g., it might be a Crown entity), it would use the term “Copyright” rather than “Crown copyright” and it would state its name without reference to the “New Zealand Government”. For example: 
+If the licensing agency is not part of the Crown (e.g., it might be a Crown entity), it would use the term “Copyright” rather than “Crown copyright” and it would state its name without reference to the “New Zealand Government”. For example:
 
 ```
 Copyright (c) 2015, Commerce Commission (New Zealand).
@@ -225,30 +225,30 @@ SpatialZone Project, Crown copyright (c) 2015, Land Information New Zealand on b
 >Note that, under this approach, if a single software file is separated from the distribution, the recipient is unlikely to see the applicable copyright notice. If this is of concern to an agency, the solution is to include a brief copyright notice in each file’s header that points to the top-level LICENSING file. For example:
 
 >```
-SpatialZone Project, Crown copyright (c) 2015, Land Information New Zealand on behalf of the New Zealand Government. This file is released under the MIT licence. See the LICENSING file found in the top-level directory of this distribution for more information. 
+SpatialZone Project, Crown copyright (c) 2015, Land Information New Zealand on behalf of the New Zealand Government. This file is released under the MIT licence. See the LICENSING file found in the top-level directory of this distribution for more information.
 ```
 
 #### Applying the GPL
 
-##### 57
+##### 56
 
-Full instructions on how to apply can be found on the Free Software Foundation’s [website](http://www.gnu.org/licenses/gpl-howto.html).[^17]
+Full instructions on how to apply can be found on the Free Software Foundation’s [website](http://www.gnu.org/licenses/gpl-howto.html).[^16]
 
-[^17]: See "How to use GNU licenses for your own software" at [http://www.gnu.org/licenses/gpl-howto.html](http://www.gnu.org/licenses/gpl-howto.html)
+[^16]: See "How to use GNU licenses for your own software" at [http://www.gnu.org/licenses/gpl-howto.html](http://www.gnu.org/licenses/gpl-howto.html)
 
 #### Other licences
 
-##### 58
+##### 57
 
-If for some reason you are applying an alternative open source software licence, you may wish to check whether the entity that maintains the licence has instructions on how to apply it. Alternatively, you could follow the approach suggested above for the MIT licence or the Free Software Foundation’s suggested approach for the GPL. 
+If for some reason you are applying an alternative open source software licence, you may wish to check whether the entity that maintains the licence has instructions on how to apply it. Alternatively, you could follow the approach suggested above for the MIT licence or the Free Software Foundation’s suggested approach for the GPL.
 
 ### Stage 5: Release the software
 
-##### 59
+##### 58
 
 Once the chosen licence has been applied to the software files, release the software for re-use into one or more relevant code repositories and/or on the agency’s website. Consider:
 
-(a) using a version control repository like GitHub; and 
+(a) using a version control repository like GitHub; and
 
 (b) whether to:
 
@@ -259,7 +259,7 @@ Once the chosen licence has been applied to the software files, release the soft
 
 ### Review and release process decision tree
 
-##### 60
+##### 59
 
 The decision tree diagram below illustrates the Review and Release Process explained above. It is intended to be read in conjunction with the explanations above for each stage.
 


### PR DESCRIPTION
The revised adaptions section takes into account [public consultation discussions](https://www.loomio.org/d/blCWMgQB/adaptions-para-19-should-cover-using-same-license-as-adapted-project-) that:
- mentioned that adaptions of existing FOSS software is very common
- users should respect and existing licences inherent in that existing software, that is, respect the licence conditions when you re-use code

There are also some tricky situations where multiple licence styles exist or you are combining multiple parts of code into a single project under different licences. We have added information to this effect and suggest users should remember that sharealike often overrides co-existing licences such as MIT if a user is going to distribute adapted source code and this is an ok thing.

We've also removed some mentions of sharealike and the principle on Alternative OSS Licencing as sharealike is now part of the default set of licences not an alternative under the old MIT default.
