### PR TITLE
Minor updates to the security disclosure process

### DIFF
--- a/markdown/gn2/02_working-in-the-open.md
+++ b/markdown/gn2/02_working-in-the-open.md
@@ -252,6 +252,8 @@ Some suggestions when you publish your open source software:
 
 * Include a summary of what contributors should do when they find a security issue in your code in your CONTRIBUTING.md documentation alongside your code. A sample insert for this is provided below.
 
+* Ensure your policy makes it clear that security reports are sought after and that reporters acting in good faith will not be prosecuted. Often the first reaction from organisations (both public and private) is to look to prosecute or litigate the issue to ensure the reporter does not disclose details of the issue. This can often mean that security researchers will find vulnerabilities but not report them for fear of prosecution. Having a policy that makes it clear this won't happen to them is key to soliciting reports from outside researchers.
+
 * Set up an email such as "security@AGENCY.govt.nz" that can be used to report issues (you may also look into ensuring this can be done securely by providing a public encryption key[^7]
 
 [^7]: [Introduction to email encryption] (https://support.mozilla.org/en-US/kb/digitally-signing-and-encrypting-messages).
@@ -262,9 +264,9 @@ Some suggestions when you publish your open source software:
 
 * Check your system for any signs of it being compromised and then fix the issue.
 
-* NZGOAL-SE suggests informing other agencies known to be using your software, the CGIO, the GCPO and the Office of the Privacy Commissioner so the widest number of users get the opportunity to apply the fix to the software before it becomes publicly disclosed.
+* NZGOAL-SE suggests informing other agencies known to be using your software, the GCIO, the GCPO and the Office of the Privacy Commissioner (if applicable) so the widest number of users get the opportunity to apply the fix to the software before it becomes publicly disclosed.
 
-* Lastly, release your fix directly to your publicly accessible code repository (and consider applying a security patch version number as discussed in the [section on Semantic Versioning](#semantic-versioning) along with an advisory note or CHANGELOG in your project documentation informing users of the known issue and prompting them to update.
+* Lastly, release your fix directly to your publicly accessible code repository (and consider applying a security patch version number as discussed in the [section on Semantic Versioning](#semantic-versioning) along with an advisory note or CHANGELOG entry in your project documentation informing users of the known issue and prompting them to update.
 
 * Publicly acknowledge the reporter for helping with the fix (if they agree).
 


### PR DESCRIPTION
The major update here is to include information about litigation/prosecution of reporters. I think it deserves to be called out especially, as making this less of an issue for white-hat hackers means it's much more likely that they will actually work with you to close the hole, instead of ignoring it.

Perhaps some example wording would help here - for example if you can access e.g. an invoicing system which has unencrypted usernames/passwords stored in it should be reported; and the researcher should not then use those details to try and access other systems. A number of bug bounty programs (e.g. Microsoft, GitHub) have rules similar to this which could help here.

The other changes are minor, and mainly factual (e.g. GICO mis-spelling of GCIO).